### PR TITLE
Fixes peer dependency warning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "inquirer": "^6.3.1"
   },
   "peerDependencies": {
-    "inquirer": "^5.0.0 || ^6.0.0 || ^7.0.0 "
+    "inquirer": "^5.0.0 || ^6.0.0 || ^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "inquirer": "^6.3.1"
   },
   "peerDependencies": {
-    "inquirer": "^5.0.0 || ^6.0.0"
+    "inquirer": "^5.0.0 || ^6.0.0 || ^7.0.0 "
   }
 }


### PR DESCRIPTION
**What is this:**
In Yarn/NPM you get this warning as of now:
`inquirer-fs-selector@1.2.0" has incorrect peer dependency "inquirer@^5.0.0 || ^6.0.0".`
This should fix the issue
